### PR TITLE
feat(tui): implement markdown email composition in TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.9.1",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +3674,7 @@ dependencies = [
  "mail-parser",
  "maplit",
  "mime",
+ "pulldown-cmark",
  "ratatui",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ scraper = "0.20"
 # TUI dependencies
 ratatui = "0.29"
 crossterm = "0.28"
+pulldown-cmark = "0.12"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["cookies", "json"] }

--- a/config.example.toml
+++ b/config.example.toml
@@ -97,6 +97,12 @@ show_sidebar = true
 # When disabled, emails are displayed as plain text (default: false)
 styled_text = false
 
+# Enable markdown composition in TUI by default
+# When enabled, new emails start in markdown mode with automatic HTML conversion
+# When disabled, emails are composed in plain text mode (default: false)
+# Note: Users can always toggle markdown mode with Ctrl+M during composition
+markdown_compose = false
+
 # General application behavior
 [general]
 # Auto-refresh interval in seconds (0 to disable)

--- a/src/bin/whynot-tui.rs
+++ b/src/bin/whynot-tui.rs
@@ -169,36 +169,41 @@ async fn run_app<B: ratatui::backend::Backend>(
                         _ => {}
                     },
                     whynot::tui::app::AppState::Compose => {
-                        match key.code {
-                            crossterm::event::KeyCode::Esc => {
-                                app.go_back();
-                            }
-                            crossterm::event::KeyCode::Tab => {
-                                app.compose_next_field();
-                            }
-                            crossterm::event::KeyCode::BackTab => {
-                                app.compose_prev_field();
-                            }
-                            crossterm::event::KeyCode::Enter => {
-                                // Handle Enter key in compose mode
-                                app.compose_handle_enter();
-                            }
-                            crossterm::event::KeyCode::Char('s')
-                                if key
-                                    .modifiers
-                                    .contains(crossterm::event::KeyModifiers::CONTROL) =>
-                            {
-                                if let Err(e) = app.send_composed_email().await {
-                                    app.set_status(format!("Send error: {}", e));
+                        // Check for markdown toggle first (using the event helper)
+                        if event.is_markdown_toggle() {
+                            app.toggle_compose_markdown_mode();
+                        } else {
+                            match key.code {
+                                crossterm::event::KeyCode::Esc => {
+                                    app.go_back();
                                 }
+                                crossterm::event::KeyCode::Tab => {
+                                    app.compose_next_field();
+                                }
+                                crossterm::event::KeyCode::BackTab => {
+                                    app.compose_prev_field();
+                                }
+                                crossterm::event::KeyCode::Enter => {
+                                    // Handle Enter key in compose mode
+                                    app.compose_handle_enter();
+                                }
+                                crossterm::event::KeyCode::Char('s')
+                                    if key
+                                        .modifiers
+                                        .contains(crossterm::event::KeyModifiers::CONTROL) =>
+                                {
+                                    if let Err(e) = app.send_composed_email().await {
+                                        app.set_status(format!("Send error: {}", e));
+                                    }
+                                }
+                                crossterm::event::KeyCode::Backspace => {
+                                    app.compose_handle_backspace();
+                                }
+                                crossterm::event::KeyCode::Char(c) => {
+                                    app.compose_handle_char(c);
+                                }
+                                _ => {}
                             }
-                            crossterm::event::KeyCode::Backspace => {
-                                app.compose_handle_backspace();
-                            }
-                            crossterm::event::KeyCode::Char(c) => {
-                                app.compose_handle_char(c);
-                            }
-                            _ => {}
                         }
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,6 +87,7 @@ pub struct TuiConfig {
     pub keybindings: Option<String>,
     pub show_sidebar: Option<bool>,
     pub styled_text: Option<bool>,
+    pub markdown_compose: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -275,6 +276,7 @@ impl Default for TuiConfig {
             keybindings: Some("vim".to_string()),
             show_sidebar: Some(true),
             styled_text: Some(false), // Default to false for backward compatibility
+            markdown_compose: Some(false), // Default to false for backward compatibility
         }
     }
 }
@@ -634,6 +636,12 @@ impl Config {
         }
         if other.ui.tui.show_sidebar.is_some() {
             base.ui.tui.show_sidebar = other.ui.tui.show_sidebar;
+        }
+        if other.ui.tui.styled_text.is_some() {
+            base.ui.tui.styled_text = other.ui.tui.styled_text;
+        }
+        if other.ui.tui.markdown_compose.is_some() {
+            base.ui.tui.markdown_compose = other.ui.tui.markdown_compose;
         }
 
         // Merge user config

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -284,4 +284,16 @@ impl Event {
             })
         )
     }
+
+    /// Check if this is a markdown toggle key (Ctrl+M)
+    pub fn is_markdown_toggle(&self) -> bool {
+        matches!(
+            self,
+            Event::Key(KeyEvent {
+                code: KeyCode::Char('m'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            })
+        )
+    }
 }

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -1,0 +1,201 @@
+//! Markdown to HTML conversion for TUI email composition.
+
+use pulldown_cmark::{html, Options, Parser};
+
+/// Converts markdown text to HTML for email composition.
+///
+/// This function takes markdown text and converts it to HTML suitable for
+/// sending as the text/html part of a multipart email message. The conversion
+/// includes proper handling of common markdown features like headers, lists,
+/// links, code blocks, and basic formatting.
+pub fn markdown_to_html(markdown: &str) -> String {
+    // Enable GitHub-flavored markdown extensions
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_FOOTNOTES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    let parser = Parser::new_ext(markdown, options);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+
+    html_output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_markdown_to_html_basic_formatting() {
+        let markdown = "**bold** and *italic* text";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<strong>bold</strong>"));
+        assert!(html.contains("<em>italic</em>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_headers() {
+        let markdown = "# Header 1\n## Header 2\n### Header 3";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<h1>Header 1</h1>"));
+        assert!(html.contains("<h2>Header 2</h2>"));
+        assert!(html.contains("<h3>Header 3</h3>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_lists() {
+        let markdown = "- Item 1\n- Item 2\n- Item 3";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<ul>"));
+        assert!(html.contains("<li>Item 1</li>"));
+        assert!(html.contains("<li>Item 2</li>"));
+        assert!(html.contains("<li>Item 3</li>"));
+        assert!(html.contains("</ul>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_ordered_lists() {
+        let markdown = "1. First\n2. Second\n3. Third";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<ol>"));
+        assert!(html.contains("<li>First</li>"));
+        assert!(html.contains("<li>Second</li>"));
+        assert!(html.contains("<li>Third</li>"));
+        assert!(html.contains("</ol>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_links() {
+        let markdown = "[Link text](https://example.com)";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<a href=\"https://example.com\">Link text</a>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_code_inline() {
+        let markdown = "Here is `inline code` example";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<code>inline code</code>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_code_block() {
+        let markdown = "```rust\nfn main() {\n    println!(\"Hello\");\n}\n```";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<pre><code"));
+        assert!(html.contains("fn main()"));
+        assert!(html.contains("println!"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_blockquotes() {
+        let markdown = "> This is a blockquote\n> with multiple lines";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<blockquote>"));
+        assert!(html.contains("This is a blockquote"));
+        assert!(html.contains("with multiple lines"));
+        assert!(html.contains("</blockquote>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_tables() {
+        let markdown = "| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<table>"));
+        assert!(html.contains("<th>Header 1</th>"));
+        assert!(html.contains("<th>Header 2</th>"));
+        assert!(html.contains("<td>Cell 1</td>"));
+        assert!(html.contains("<td>Cell 2</td>"));
+        assert!(html.contains("</table>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_strikethrough() {
+        let markdown = "~~strikethrough text~~";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<del>strikethrough text</del>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_paragraphs() {
+        let markdown = "First paragraph.\n\nSecond paragraph.";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<p>First paragraph.</p>"));
+        assert!(html.contains("<p>Second paragraph.</p>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_line_breaks() {
+        let markdown = "Line 1  \nLine 2";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("Line 1<br />"));
+        assert!(html.contains("Line 2"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_empty_input() {
+        let html = markdown_to_html("");
+        assert_eq!(html, "");
+    }
+
+    #[test]
+    fn test_markdown_to_html_plain_text() {
+        let markdown = "Just plain text with no markdown";
+        let html = markdown_to_html(markdown);
+        assert!(html.contains("<p>Just plain text with no markdown</p>"));
+    }
+
+    #[test]
+    fn test_markdown_to_html_complex_email() {
+        let markdown = r#"# Email Subject
+
+Hello **John**,
+
+I hope this email finds you well. Here are the key points:
+
+- First point with *emphasis*
+- Second point with [a link](https://example.com)
+- Third point with `inline code`
+
+## Code Example
+
+```rust
+fn greet(name: &str) {
+    println!("Hello, {}!", name);
+}
+```
+
+> This is an important note that should be highlighted.
+
+Best regards,  
+Jane
+
+---
+
+P.S. Check out this table:
+
+| Feature | Status |
+|---------|--------|
+| Markdown | ✅ |
+| HTML | ✅ |
+"#;
+
+        let html = markdown_to_html(markdown);
+        
+        // Check major components are present
+        assert!(html.contains("<h1>Email Subject</h1>"));
+        assert!(html.contains("<strong>John</strong>"));
+        assert!(html.contains("<em>emphasis</em>"));
+        assert!(html.contains("<a href=\"https://example.com\">a link</a>"));
+        assert!(html.contains("<code>inline code</code>"));
+        assert!(html.contains("<h2>Code Example</h2>"));
+        assert!(html.contains("<pre><code"));
+        assert!(html.contains("fn greet"));
+        assert!(html.contains("<blockquote>"));
+        assert!(html.contains("<table>"));
+        assert!(html.contains("<th>Feature</th>"));
+        assert!(html.contains("<td>✅</td>"));
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod events;
+pub mod markdown;
 pub mod ui;
 
 pub use app::App;

--- a/tests/tui_app_markdown_tests.rs
+++ b/tests/tui_app_markdown_tests.rs
@@ -1,0 +1,48 @@
+//! Tests for TUI App markdown toggle functionality
+
+use whynot::tui::app::{AppState, ComposeForm, ComposeMode};
+
+#[test]
+fn test_compose_form_markdown_mode_field_exists() {
+    let mut form = ComposeForm::default();
+    
+    // Should default to false
+    assert_eq!(form.markdown_mode, false);
+    
+    // Should be able to toggle
+    form.markdown_mode = true;
+    assert_eq!(form.markdown_mode, true);
+}
+
+#[test]
+fn test_compose_form_with_explicit_markdown_mode() {
+    let form = ComposeForm {
+        mode: ComposeMode::New,
+        markdown_mode: true,
+        to: "test@example.com".to_string(),
+        subject: "Test".to_string(),
+        body: "# Hello World\n\nThis is **markdown**.".to_string(),
+        ..Default::default()
+    };
+    
+    assert_eq!(form.markdown_mode, true);
+    assert_eq!(form.mode, ComposeMode::New);
+    assert_eq!(form.to, "test@example.com");
+    assert!(form.body.contains("# Hello World"));
+}
+
+#[test]
+fn test_app_state_compare() {
+    // Test that AppState comparison works for our tests
+    assert_eq!(AppState::Compose, AppState::Compose);
+    assert_eq!(AppState::EmailList, AppState::EmailList);
+    assert_ne!(AppState::Compose, AppState::EmailList);
+}
+
+#[test]
+fn test_compose_mode_compare() {
+    // Test that ComposeMode comparison works for our tests
+    assert_eq!(ComposeMode::New, ComposeMode::New);
+    assert_eq!(ComposeMode::Reply("id1".to_string()), ComposeMode::Reply("id1".to_string()));
+    assert_ne!(ComposeMode::New, ComposeMode::Reply("id".to_string()));
+}

--- a/tests/tui_markdown_compose_tests.rs
+++ b/tests/tui_markdown_compose_tests.rs
@@ -1,0 +1,77 @@
+//! Tests for TUI markdown compose functionality
+
+use whynot::tui::app::{ComposeForm, ComposeMode};
+
+#[test]
+fn test_compose_form_has_markdown_mode_field() {
+    let mut form = ComposeForm::default();
+    
+    // Should start with markdown_mode as false by default
+    assert_eq!(form.markdown_mode, false);
+    
+    // Should be able to toggle markdown_mode
+    form.markdown_mode = true;
+    assert_eq!(form.markdown_mode, true);
+    
+    form.markdown_mode = false;
+    assert_eq!(form.markdown_mode, false);
+}
+
+#[test]
+fn test_compose_form_markdown_mode_with_different_modes() {
+    // Test that markdown_mode works with all compose modes
+    let new_form = ComposeForm {
+        mode: ComposeMode::New,
+        markdown_mode: true,
+        ..Default::default()
+    };
+    assert_eq!(new_form.markdown_mode, true);
+    
+    let reply_form = ComposeForm {
+        mode: ComposeMode::Reply("test-id".to_string()),
+        markdown_mode: false,
+        ..Default::default()
+    };
+    assert_eq!(reply_form.markdown_mode, false);
+    
+    let reply_all_form = ComposeForm {
+        mode: ComposeMode::ReplyAll("test-id".to_string()),
+        markdown_mode: true,
+        ..Default::default()
+    };
+    assert_eq!(reply_all_form.markdown_mode, true);
+    
+    let forward_form = ComposeForm {
+        mode: ComposeMode::Forward("test-id".to_string()),
+        markdown_mode: false,
+        ..Default::default()
+    };
+    assert_eq!(forward_form.markdown_mode, false);
+}
+
+#[test]
+fn test_compose_form_preserves_other_fields_with_markdown() {
+    let mut form = ComposeForm {
+        to: "test@example.com".to_string(),
+        cc: "cc@example.com".to_string(),
+        subject: "Test Subject".to_string(),
+        body: "Test body content".to_string(),
+        markdown_mode: true,
+        ..Default::default()
+    };
+    
+    // Verify all fields are preserved when markdown_mode is set
+    assert_eq!(form.to, "test@example.com");
+    assert_eq!(form.cc, "cc@example.com");
+    assert_eq!(form.subject, "Test Subject");
+    assert_eq!(form.body, "Test body content");
+    assert_eq!(form.markdown_mode, true);
+    
+    // Toggle markdown_mode and verify other fields are unchanged
+    form.markdown_mode = false;
+    assert_eq!(form.to, "test@example.com");
+    assert_eq!(form.cc, "cc@example.com");
+    assert_eq!(form.subject, "Test Subject");
+    assert_eq!(form.body, "Test body content");
+    assert_eq!(form.markdown_mode, false);
+}

--- a/tests/tui_markdown_config_tests.rs
+++ b/tests/tui_markdown_config_tests.rs
@@ -1,0 +1,51 @@
+//! Tests for TUI markdown configuration options
+
+use whynot::config::{Config, TuiConfig};
+
+#[test]
+fn test_tui_config_markdown_compose_default() {
+    let config = TuiConfig::default();
+    
+    // markdown_compose should default to false for backward compatibility
+    assert_eq!(config.markdown_compose, Some(false));
+}
+
+#[test]
+fn test_tui_config_markdown_compose_can_be_set() {
+    let mut config = TuiConfig::default();
+    config.markdown_compose = Some(true);
+    
+    assert_eq!(config.markdown_compose, Some(true));
+}
+
+#[test] 
+fn test_config_loading_with_markdown_compose() {
+    // Test that the config can be parsed from TOML with markdown_compose setting
+    let toml_content = r#"
+        [ui.tui]
+        markdown_compose = true
+        styled_text = false
+        keybindings = "vim"
+    "#;
+    
+    let config: Config = toml::from_str(toml_content).expect("Failed to parse TOML");
+    assert_eq!(config.ui.tui.markdown_compose, Some(true));
+    assert_eq!(config.ui.tui.styled_text, Some(false));
+    assert_eq!(config.ui.tui.keybindings, Some("vim".to_string()));
+}
+
+#[test]
+fn test_config_loading_without_markdown_compose() {
+    // Test that the config works when markdown_compose is not specified (will be None)
+    let toml_content = r#"
+        [ui.tui]
+        styled_text = true
+        keybindings = "emacs"
+    "#;
+    
+    let config: Config = toml::from_str(toml_content).expect("Failed to parse TOML");
+    // Should be None when not specified in TOML (defaults apply later in app logic)
+    assert_eq!(config.ui.tui.markdown_compose, None);
+    assert_eq!(config.ui.tui.styled_text, Some(true));
+    assert_eq!(config.ui.tui.keybindings, Some("emacs".to_string()));
+}

--- a/tests/tui_markdown_keybinding_tests.rs
+++ b/tests/tui_markdown_keybinding_tests.rs
@@ -1,0 +1,68 @@
+//! Tests for TUI markdown keybinding functionality
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use whynot::tui::events::Event;
+
+#[test]
+fn test_ctrl_m_is_markdown_toggle() {
+    let event = Event::Key(KeyEvent {
+        code: KeyCode::Char('m'),
+        modifiers: KeyModifiers::CONTROL,
+        kind: crossterm::event::KeyEventKind::Press,
+        state: crossterm::event::KeyEventState::NONE,
+    });
+    
+    assert!(event.is_markdown_toggle());
+}
+
+#[test]
+fn test_regular_m_is_not_markdown_toggle() {
+    let event = Event::Key(KeyEvent {
+        code: KeyCode::Char('m'),
+        modifiers: KeyModifiers::NONE,
+        kind: crossterm::event::KeyEventKind::Press,
+        state: crossterm::event::KeyEventState::NONE,
+    });
+    
+    assert!(!event.is_markdown_toggle());
+}
+
+#[test]
+fn test_shift_m_is_not_markdown_toggle() {
+    let event = Event::Key(KeyEvent {
+        code: KeyCode::Char('M'),
+        modifiers: KeyModifiers::SHIFT,
+        kind: crossterm::event::KeyEventKind::Press,
+        state: crossterm::event::KeyEventState::NONE,
+    });
+    
+    assert!(!event.is_markdown_toggle());
+}
+
+#[test]
+fn test_other_ctrl_keys_not_markdown_toggle() {
+    let events = vec![
+        Event::Key(KeyEvent {
+            code: KeyCode::Char('n'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }),
+        Event::Key(KeyEvent {
+            code: KeyCode::Char('s'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }),
+        Event::Key(KeyEvent {
+            code: KeyCode::Char('c'),
+            modifiers: KeyModifiers::CONTROL,
+            kind: crossterm::event::KeyEventKind::Press,
+            state: crossterm::event::KeyEventState::NONE,
+        }),
+    ];
+    
+    for event in events {
+        assert!(!event.is_markdown_toggle());
+    }
+}

--- a/tests/tui_markdown_send_tests.rs
+++ b/tests/tui_markdown_send_tests.rs
@@ -1,0 +1,91 @@
+//! Tests for TUI markdown email sending functionality
+
+use whynot::tui::markdown::markdown_to_html;
+
+#[test]
+fn test_markdown_conversion_for_email_body() {
+    let markdown_body = r#"# Hello
+
+This is a **bold** message with:
+
+- Point 1
+- Point 2
+
+[Link](https://example.com)
+
+```rust
+fn hello() {
+    println!("world");
+}
+```
+
+Best regards!"#;
+
+    let html_body = markdown_to_html(markdown_body);
+    
+    // Verify HTML contains expected elements
+    assert!(html_body.contains("<h1>Hello</h1>"));
+    assert!(html_body.contains("<strong>bold</strong>"));
+    assert!(html_body.contains("<ul>"));
+    assert!(html_body.contains("<li>Point 1</li>"));
+    assert!(html_body.contains("<li>Point 2</li>"));
+    assert!(html_body.contains("<a href=\"https://example.com\">Link</a>"));
+    assert!(html_body.contains("<pre><code"));
+    assert!(html_body.contains("fn hello()"));
+    assert!(html_body.contains("Best regards"));
+}
+
+#[test]
+fn test_plain_text_remains_unchanged() {
+    let plain_text = "Just plain text\nwith line breaks\nand nothing special.";
+    let html_body = markdown_to_html(plain_text);
+    
+    // Should be wrapped in paragraphs but otherwise unchanged
+    assert!(html_body.contains("<p>Just plain text"));
+    assert!(html_body.contains("with line breaks"));
+    assert!(html_body.contains("and nothing special.</p>"));
+}
+
+#[test]
+fn test_email_signature_markdown() {
+    let markdown_with_signature = r#"Hi John,
+
+Thanks for your **quick response**. The proposal looks good.
+
+Best regards,
+*Jane Smith*  
+Senior Developer"#;
+
+    let html_body = markdown_to_html(markdown_with_signature);
+    
+    // Check formatting is preserved
+    assert!(html_body.contains("<strong>quick response</strong>"));
+    assert!(html_body.contains("<em>Jane Smith</em>"));
+    assert!(html_body.contains("Senior Developer"));
+}
+
+#[test]
+fn test_markdown_email_with_code_and_links() {
+    let technical_email = r#"## Status Update
+
+The `main` function has been updated:
+
+```rust
+fn main() {
+    println!("Hello, world!");
+}
+```
+
+Please review the changes at: https://github.com/example/repo
+
+Thanks!"#;
+
+    let html_body = markdown_to_html(technical_email);
+    
+    // Verify technical content is properly formatted
+    assert!(html_body.contains("<h2>Status Update</h2>"));
+    assert!(html_body.contains("<code>main</code>"));
+    assert!(html_body.contains("<pre><code"));
+    assert!(html_body.contains("println!"));
+    assert!(html_body.contains("https://github.com/example/repo"));
+}


### PR DESCRIPTION
- Add markdown-to-HTML conversion for email composition
- Support both text/plain (markdown) and text/html (converted) parts
- Add ui.tui.markdown_compose configuration option
- Implement Ctrl+M toggle for dynamic mode switching
- Maintain backward compatibility with existing compose workflow