### PR TITLE
fix(tests): handle Option<String> in NotmuchClient::show doctest

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -248,7 +248,7 @@ pub trait NotmuchClient: Send + Sync {
     ///     
     ///     for message in thread.get_messages() {
     ///         println!("From: {}", message.headers.from);
-    ///         println!("Subject: {}", message.headers.subject);
+    ///         println!("Subject: {}", message.headers.subject.as_deref().unwrap_or("(no subject)"));
     ///     }
     /// }
     /// # Ok(())


### PR DESCRIPTION
Fix compilation error in doctest at src/client/mod.rs:252 where message.headers.subject (Option<String>) was being printed directly. Now properly handles the Option with .as_deref().unwrap_or() fallback.